### PR TITLE
Fix warning Cannot read property 'right' of null

### DIFF
--- a/ordered_relation_editor/qml/OrderedImageList.qml
+++ b/ordered_relation_editor/qml/OrderedImageList.qml
@@ -20,7 +20,7 @@ Rectangle {
             property int indexFrom: -1
             property int indexTo: -1
 
-            anchors { left: parent.left; right: parent.right }
+            width: listView.width
             height: content.height
 
             drag.target: held ? content : undefined


### PR DESCRIPTION
In delegates `parent` should not be used as it can become null in some situations (Starting from Qt 5.15.0).
See [https://bugreports.qt.io/browse/QTBUG-81976](https://bugreports.qt.io/browse/QTBUG-81976)