### PR TITLE
Avoid showing first feature by default, defer attribute form creation until first feature shown

### DIFF
--- a/ordered_relation_editor/ui/ordered_relation_editor_widget.ui
+++ b/ordered_relation_editor/ui/ordered_relation_editor_widget.ui
@@ -31,6 +31,12 @@
       </property>
      </widget>
      <widget class="QWidget" name="mAttributeFormView" native="true">
+      <property name="sizePolicy">
+       <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+        <horstretch>1</horstretch>
+        <verstretch>0</verstretch>
+       </sizepolicy>
+      </property>
       <layout class="QGridLayout" name="gridLayout_2">
        <property name="leftMargin">
         <number>0</number>


### PR DESCRIPTION
@3nids , this PR further reduce UI freeze by doing two things:
- deferring the creation of the attribute form until a valid feature is provided
- avoid automatically showing the first child feature (to prevent cascading cost, like done in https://github.com/qgis/QGIS/pull/45735)

I didn't implement a UI to toggle the show first child feature behavior, didn't think it was worth spending the extra time. Let me know if you want it anyways.