### PR TITLE
Fix switch feature crash when editing is on

### DIFF
--- a/ordered_relation_editor/core/ordered_relation_model.py
+++ b/ordered_relation_editor/core/ordered_relation_model.py
@@ -40,6 +40,9 @@ class OrderedRelationModel(QAbstractTableModel):
         self._feature = feature
         self.reloadData()
 
+        # emit a currentFeatureChanged signal with an invalid feature to reset the widget
+        self.currentFeatureChanged.emit(QgsFeature())
+
         self._relation.referencingLayer().editingStarted.connect(self.editingStarted)
         self._relation.referencingLayer().editingStopped.connect(self.editingStopped)
 
@@ -172,8 +175,6 @@ class OrderedRelationModel(QAbstractTableModel):
             self._related_features = sorted(self._related_features, key=lambda _f: _f[self._ordering_field])
 
         self.endResetModel()
-        # emit a currentFeatureChanged signal with an invalid feature to reset the widget
-        self.currentFeatureChanged.emit(QgsFeature())
 
 
 

--- a/ordered_relation_editor/qml/OrderedImageList.qml
+++ b/ordered_relation_editor/qml/OrderedImageList.qml
@@ -13,7 +13,7 @@ Rectangle {
 
         MouseArea {
             id: dragArea
-            pressAndHoldInterval: 130
+            pressAndHoldInterval: 250
 
             property bool held: false
 


### PR DESCRIPTION
@3nids , this fixes the crash when switching feature while layer editing is on. This regressed when fixing another bug in November (the stacktrace when switching parent features). I've tested that too here and things are good, but make sure you test that too to insure we're not re-regressing on the other front :)

BTW, while doing some testing in edit mode, I found the press and hold interval to be way to low, half of my attempts are switching features were misregistering as an attempt to move an item. I've _slightly_ increased the interval from 130ms to 250ms.